### PR TITLE
Texture was flipped horizontally. This fixes it.

### DIFF
--- a/4_image-effects/4-9_single-pass-blur/effect.frag
+++ b/4_image-effects/4-9_single-pass-blur/effect.frag
@@ -11,7 +11,7 @@ void main() {
 
   vec2 uv = vTexCoord;
   // the texture is loaded upside down and backwards by default so lets flip it
-  uv = 1.0 - uv;
+  uv = vec2(uv.x, 1.0 - uv.y);
 
   // a single pass blur works by sampling all the neighbor pixels and averaging them up
   // this is somewhat inefficient because we have to sample the texture 9 times -- texture2D calls are slow :( 


### PR DESCRIPTION
Hello,

I was using your amazing shaders (thanks for that!), but the single pass blur was still flipping horizontally the texture. I've found that by flipping it only vertically does the trick. Does it make sense?
